### PR TITLE
Fix #5: Use custom exception

### DIFF
--- a/injections/__init__.py
+++ b/injections/__init__.py
@@ -1,6 +1,7 @@
 from .core import (
     Container,
     Dependency,
+    MissingDependencyError,
     has,
     depends,
     propagate,
@@ -11,6 +12,7 @@ from .core import (
 __all__ = [
     'Container',
     'Dependency',
+    'MissingDependencyError',
     'has',
     'depends',
     'propagate',

--- a/injections/core.py
+++ b/injections/core.py
@@ -76,6 +76,13 @@ class Dependency:
 depends = Dependency  # nicer declarative name
 
 
+class MissingDependencyError(KeyError):
+    """Required dependency is missed in container"""
+
+    def __str__(self):
+        return "Dependency {!r} is missed in container".format(self.args[0])
+
+
 class Container(object):
     """Container for things that will be dependency-injected
 
@@ -104,7 +111,10 @@ class Container(object):
         deps = getattr(inst, '__injections__', None)
         if deps:
             for attr, dep in deps.items():
-                val = pro[dep.name]
+                val = pro.get(dep.name)
+                if val is None:
+                    raise MissingDependencyError(dep.name)
+
                 if not isinstance(val, dep.type):
                     raise TypeError("Wrong provider for {!r}".format(val))
                 setattr(inst, attr, val)

--- a/injections/test_core.py
+++ b/injections/test_core.py
@@ -136,6 +136,11 @@ class TestCore(TestCase):
             a = di.depends(int)
             b = di.depends(int)
 
-        with self.assertRaisesRegex(di.MissingDependencyError,
-                                    "Dependency 'b' is missed in container"):
+        if hasattr(self, 'assertRaisesRegex'):
+            checker = self.assertRaisesRegex
+        else:
+            checker = self.assertRaisesRegexp
+
+        with checker(di.MissingDependencyError,
+                     "Dependency 'b' is missed in container"):
             c.inject(Consumer())

--- a/injections/test_core.py
+++ b/injections/test_core.py
@@ -126,3 +126,16 @@ class TestCore(TestCase):
         c['name'] = 1
         with self.assertRaises(TypeError):
             c.inject(self.Consumer())
+
+    def test_missing_dependency(self):
+        c = di.Container()
+        c['a'] = 1
+
+        @di.has
+        class Consumer:
+            a = di.depends(int)
+            b = di.depends(int)
+
+        with self.assertRaisesRegex(di.MissingDependencyError,
+                                    "Dependency 'b' is missed in container"):
+            c.inject(Consumer())

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(name='injections',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 2',
         ],
+      license='MIT',
      )


### PR DESCRIPTION
 for injecting container into object with unknown dependencies
